### PR TITLE
Use Apiary to populate page with updated info

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ ensures that W3C standards will remain free for everyone to use, now and in the 
 
 <p>The Verifiable Claims Working Group (VCWG) co-chairs are:</p>
 
-<p data-apiary="chairs ${name}"></p>
+<div data-apiary="chairs ${name}"></div>
 
 The W3C team contact is <a href="mailto:liam@w3.org">Liam Quin</a>.</p>
 
@@ -80,7 +80,7 @@ to the public-vc-wg mailing list.</p>
 
 <h2>Our Documents</h2>
 
-<p data-apiary="specifications" />
+<div data-apiary="specifications"></div>
 
 <ul>
 <li>Verifiable Claims Use Cases:

--- a/index.html
+++ b/index.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 
-<html lang="en">
+<html lang="en" data-apiary-key="c5oe47cc7l4oookck8co4o4owg4w4o8" data-apiary-group="98922">
 <head>
 <meta charset="utf-8">
 <title>W3C Verifiable Claims Working Group</title>
 <meta name="mobile-web-app-capable" content="yes">
-<meta name="viewport" content="width=device-width, initial-scale=1, initial-scale = 1.0, 
+<meta name="viewport" content="width=device-width, initial-scale=1, initial-scale = 1.0,
 shrink-to-fit=no">
 <link rel="stylesheet" href="css/main.css">
 <script async type="text/javascript" src="js/newsfeed.js"> </script>
@@ -35,15 +35,19 @@ expressing and exchanging claims that have been verified by
 a third party
 easier and more secure on the Web.</p>
 
-<p>We produce standards that are protected by the <a 
-href="https://www.w3.org/2004/01/pp-impl/83482/status">W3C Royalty-free Patent Policy</a>. This 
+<p>We produce standards that are protected by the <a
+href="https://www.w3.org/2004/01/pp-impl/83482/status">W3C Royalty-free Patent Policy</a>. This
 ensures that W3C standards will remain free for everyone to use, now and in the future.</p>
+
+<p data-apiary="description" />
 
 </section>
 
 <h2>Who we are</h2>
 
-<p>The Verifiable Claims Working Group (VCWG) co-chairs are Matt Stone, Pearson; Richard Varn, ETS, and Daniel Burnett, Invited Expert.</p>
+<p>The Verifiable Claims Working Group (VCWG) co-chairs are:</p>
+
+<p data-apiary="chairs ${name}"></p>
 
 The W3C team contact is <a href="mailto:liam@w3.org">Liam Quin</a>.</p>
 
@@ -53,7 +57,7 @@ the Verifiable Claims Working Group</a>.</p>
 
 <h2>Get involved</h2>
 
-<p>We welcome comments and discussion from the web community, on GitHub and our <a href="#emails">email 
+<p>We welcome comments and discussion from the web community, on GitHub and our <a href="#emails">email
 lists</a>.</p>
 
 <p>We also welcome new members:</p>
@@ -65,7 +69,7 @@ lists</a>.</p>
 
 <h3 id="emails">Our email lists</h3>
 
-<p>We use the <a href="https://lists.w3.org/Archives/Public/public-vc-wg/">public-vc-wg 
+<p>We use the <a href="https://lists.w3.org/Archives/Public/public-vc-wg/">public-vc-wg
 email</a> for all technical discussions.</p>
 <p>There is also a Member-only list just for administration, such as telephone numbers for weekly calls.</p>
 
@@ -74,20 +78,25 @@ email</a> for all technical discussions.</p>
 <p>We meet at 11am Eastern US Time on Tuesday each week, and agendas and minutes are sent
 to the public-vc-wg mailing list.</p>
 
-  <h2>Our Documents</h2>
-  <p>Official link to <a href="https://www.w3.org/TR/verifiable-claims-use-cases/">Verifiable Claims Use Cases</a>;
-    <a href="https://w3c.github.io/vc-use-cases/">editor's draft</a>
-    and <a href="https://github.com/w3c/vc-data-model/">github page with issue tracker</a>.</p>
-  
-  <p>Official link to
-    <a href="https://www.w3.org/TR/verifiable-claims-use-cases/">Verifiable Claims Data Model and Representations</a>;
-    <a href="https://w3c.github.io/vc-data-model/">editor's draft</a>
-        and <a href="https://github.com/w3c/vc-use-cases/">github page with issue tracker</a>.</p>
+<h2>Our Documents</h2>
 
-  
+<p data-apiary="specifications" />
+
+<ul>
+<li>Verifiable Claims Use Cases:
+<a href="https://w3c.github.io/vc-use-cases/">editor's draft</a>
+and <a href="https://github.com/w3c/vc-data-model/">github page with issue tracker</a>.</li>
+<li>Verifiable Claims Data Model and Representations:
+<a href="https://w3c.github.io/vc-data-model/">editor's draft</a>
+and <a href="https://github.com/w3c/vc-use-cases/">github page with issue tracker</a>.</li>
+</ul>
+
 <h2>Our charter</h2>
 
-<p>The <a href="https://www.w3.org/2017/vc/charter.html">VCWG Charter</a> is publicly readable.</p>
+<p>The <a href="https://www.w3.org/2017/vc/charter.html">VCWG Charter</a>
+    (from <span data-apiary="start-date"></span> to <span data-apiary="end-date"></span>)
+    is publicly readable.
+</p>
 
 <section id="articles">
 <!--* put article elements here with h2 and then p... *-->
@@ -99,11 +108,12 @@ to the public-vc-wg mailing list.</p>
 <footer>
 <address>
 <p id="copyright">
-<a href="https://www.w3.org/">W3C</a> - <a 
-href="https://www.w3.org/Consortium/Legal/privacy-statement">Privacy</a> - <a 
+<a href="https://www.w3.org/">W3C</a> - <a
+href="https://www.w3.org/Consortium/Legal/privacy-statement">Privacy</a> - <a
 href='http://www.w3.org/Consortium/Legal/ipr-notice'>Terms</a>
 </p>
 </footer>
 
+<script src="https://w3c.github.io/apiary/apiary.js"></script>
 </body>
 </html>


### PR DESCRIPTION
eg: description, co-chairs, specs, dates of current charter.

This ensures the page stays updated after chairs change, new specs are published, etc.

An example of its utility is that the link to the *Verifiable Claims Data Model and Representations* spec was wrong; now that it's coming from the DB it is fixed.

Using https://github.com/w3c/apiary