### PR TITLE
Add links to VC github repos and w3c group email archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 W3C Verfiable Claims Working Group
 
 Group page: [https://www.w3.org/2017/vc/WG/](https://www.w3.org/2017/vc/WG/)
+
+### Verifiable Claims github repos
+* [Data Model](https://github.com/w3c/vc-data-model)
+* [Use Cases](https://github.com/w3c/vc-use-cases)

--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ Group page: [https://www.w3.org/2017/vc/WG/](https://www.w3.org/2017/vc/WG/)
 ### Verifiable Claims github repos
 * [Data Model](https://github.com/w3c/vc-data-model)
 * [Use Cases](https://github.com/w3c/vc-use-cases)
+
+### Other useful links
+* [public group email archive](https://lists.w3.org/Archives/Public/public-vc-wg/)


### PR DESCRIPTION
Add a section in README.md for links to the VCWG repos in github.