### PR TITLE
Stonematt add stone as chair

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -28,9 +28,10 @@
 	    make expressing and exchanging credentials that have been verified
 	    by a third party easier and more secure on the Web.
 	    <p>
-		<p> The Chair of the Working Group is:</p>
+		<p> The Chairs of the Working Group are:</p>
 		<ul>
 		    <li><a href="mailto:daniel.burnett@consensys.net">Daniel Burnett</a>
+		    <li><a href="mailto:mstone@stonecover.com">Matt Stone</a>
 		</ul>
 		<p>The W3C Staff Contact for the Working Group is</p>
 		<ul>

--- a/charter.html
+++ b/charter.html
@@ -58,7 +58,8 @@
         </tr>
         <tr>
             <th rowspan="1" colspan="1">Chairs</th>
-            <td rowspan="1" colspan="1">Daniel Burnett, ConsenSys
+            <td rowspan="1" colspan="1">Daniel Burnett, ConsenSys<br/>
+                                        Matt Stone
             </td>
         </tr>
         <tr>

--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ layout: home
 {: data-apiary="description"}
 
 
-The Co-Chairs of the Working Group are [Daniel Burnett](mailto:daniel.burnett@consensys.net). The W3C Staff Contact for the Working Group is [Kazuyuki Ashimura](mailto:ashimura@w3.org).
+The Co-Chairs of the Working Group are [Daniel Burnett](mailto:daniel.burnett@consensys.net) and
+[Matt Stone](mailto:mstone@stonecover.com). The W3C Staff Contact for the Working Group is [Kazuyuki Ashimura](mailto:ashimura@w3.org).
 
 


### PR DESCRIPTION
I was removed as Chair when I left Pearson, but should have been updated as an Invited Expert.  I've been performing the chair duties throughout.